### PR TITLE
[INC-11] Fix titles in slot list view compression resistance priority.

### DIFF
--- a/Sources/RunsquitoKit/Module/SlotDetail/View/Cell/SlotDetailTableViewCell.swift
+++ b/Sources/RunsquitoKit/Module/SlotDetail/View/Cell/SlotDetailTableViewCell.swift
@@ -22,6 +22,7 @@ final class SlotDetailTableViewCell: UITableViewCell {
     
     private let keyLabel: UILabel = {
         let view = UILabel()
+        view.lineBreakMode = .byTruncatingHead
         view.textAlignment = .right
         view.textColor = .gray
         view.font = .systemFont(ofSize: 16)
@@ -49,6 +50,7 @@ final class SlotDetailTableViewCell: UITableViewCell {
     
     private let valueLabel: UILabel = {
         let view = UILabel()
+        view.lineBreakMode = .byTruncatingHead
         view.textAlignment = .right
         view.textColor = .gray
         view.font = .systemFont(ofSize: 16)

--- a/Sources/RunsquitoKit/Module/SlotList/View/Cell/SlotListTableViewCell.swift
+++ b/Sources/RunsquitoKit/Module/SlotList/View/Cell/SlotListTableViewCell.swift
@@ -12,7 +12,8 @@ final class SlotListTableViewCell: UITableViewCell {
     // MARK: - View
     private let keyTitleLabel: UILabel = {
         let view = UILabel()
-        view.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        view.setContentHuggingPriority(.required, for: .horizontal)
+        view.setContentCompressionResistancePriority(.required, for: .horizontal)
         view.font = .systemFont(ofSize: 16)
         view.text = "slot_list_key_title".localized
         
@@ -21,6 +22,7 @@ final class SlotListTableViewCell: UITableViewCell {
     
     private let keyLabel: UILabel = {
         let view = UILabel()
+        view.lineBreakMode = .byTruncatingHead
         view.textAlignment = .right
         view.textColor = .gray
         view.font = .systemFont(ofSize: 16)
@@ -38,7 +40,8 @@ final class SlotListTableViewCell: UITableViewCell {
     
     private let valueTitleLabel: UILabel = {
         let view = UILabel()
-        view.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        view.setContentHuggingPriority(.required, for: .horizontal)
+        view.setContentCompressionResistancePriority(.required, for: .horizontal)
         view.font = .systemFont(ofSize: 16)
         view.text = "slot_list_value_title".localized
         
@@ -47,6 +50,7 @@ final class SlotListTableViewCell: UITableViewCell {
     
     private let valueLabel: UILabel = {
         let view = UILabel()
+        view.lineBreakMode = .byTruncatingHead
         view.textAlignment = .right
         view.textColor = .gray
         view.font = .systemFont(ofSize: 16)
@@ -64,7 +68,8 @@ final class SlotListTableViewCell: UITableViewCell {
     
     private let storageTitleLabel: UILabel = {
         let view = UILabel()
-        view.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        view.setContentHuggingPriority(.required, for: .horizontal)
+        view.setContentCompressionResistancePriority(.required, for: .horizontal)
         view.font = .systemFont(ofSize: 16)
         view.text = "slot_list_storage_title".localized
         


### PR DESCRIPTION
# 📌 Reference
> Add any references to help understand this pull request.


# 🔥 Cause
> If there is a reason, write why the code changes was occurred.

Title label's compression resistance priority set default.

It cause break of layout.

# 📄 Changes
> Write what is changed.
> You can write more detail informations using MD syntax.

- Set title label's content compression resistance priority to `required` for `horizontal`.
- Set truncate mode of value label to `head`. because tail text is more important.

# 🚧 Testing
> Write how to test and results of changes using screenshots, gifs, any others.

## Screenshot
|<img src="https://user-images.githubusercontent.com/11141077/138309845-71a0db96-aff2-4860-a48b-d58a6d686f89.png" width=300 />|
|-|


