### PR TITLE
[INC-10] Fix to slot value update when slot value reset.

### DIFF
--- a/Sources/RunsquitoKit/Module/SlotDetail/SlotDetailViewController.swift
+++ b/Sources/RunsquitoKit/Module/SlotDetail/SlotDetailViewController.swift
@@ -212,6 +212,8 @@ extension SlotDetailViewController: UITableViewDelegate {
         case .reset:
             try? slot.setValue(nil)
             
+            delegate?.viewControllerDidChange(self)
+            
             tableView.reloadData()
             
             showToast(title: "slot_detail_reset_taost_title".localized)


### PR DESCRIPTION
# 📌 Reference
> Add any references to help understand this pull request.


# 🔥 Cause
> If there is a reason, write why the code changes was occurred.

When slot value reset in `SlotDetail`, not call delegate event.

# 📄 Changes
> Write what is changed.
> You can write more detail informations using MD syntax.

Call delegate event when value reset.

# 🚧 Testing
> Write how to test and results of changes using screenshots, gifs, any others.

|<img src="https://user-images.githubusercontent.com/11141077/138310928-2426ca2e-0c6a-41bd-aa0d-29558b544160.gif" width=300 />|
|-|

