### PR TITLE
[INC-13] Fix done button not working in `ValueEdit`.

### DIFF
--- a/Sources/RunsquitoKit/Module/SlotDetail/View/Cell/SlotValueTableViewCell.swift
+++ b/Sources/RunsquitoKit/Module/SlotDetail/View/Cell/SlotValueTableViewCell.swift
@@ -20,7 +20,7 @@ final class SlotValueTableViewCell: UITableViewCell {
     
     private let arrowButton: UIButton = {
         let view = UIButton()
-        view.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        view.setContentHuggingPriority(.required, for: .horizontal)
         view.setImage(R.Icon.arrowRight, for: .normal)
         
         return view

--- a/Sources/RunsquitoKit/Module/ValueEdit/View/Cell/ValueEditTableViewCell.swift
+++ b/Sources/RunsquitoKit/Module/ValueEdit/View/Cell/ValueEditTableViewCell.swift
@@ -14,7 +14,7 @@ protocol ValueEditTableViewCellDelegate: AnyObject {
 
 final class ValueEditTableViewCell: UITableViewCell {
     // MARK: - View
-    private let keyboardAccessoryView: UIToolbar = {
+    private lazy var keyboardAccessoryView: UIToolbar = {
         let view = UIToolbar()
         view.sizeToFit()
         
@@ -24,7 +24,7 @@ final class ValueEditTableViewCell: UITableViewCell {
             title: "done_title".localized,
             style: .done,
             target: self,
-            action: #selector(doneButtonTap(_:))
+            action: #selector(self.doneButtonTap(_:))
         )
         
         view.items = [spacer, doneButton]

--- a/Sources/RunsquitoKit/Module/ValueEdit/View/Cell/ValueUpdateKeyTableViewCell.swift
+++ b/Sources/RunsquitoKit/Module/ValueEdit/View/Cell/ValueUpdateKeyTableViewCell.swift
@@ -14,7 +14,7 @@ protocol ValueUpdateKeyTableViewCellDelegate: AnyObject {
 
 final class ValueUpdateKeyTableViewCell: UITableViewCell {
     // MARK: - View
-    private let keyboardAccessoryView: UIToolbar = {
+    private lazy var keyboardAccessoryView: UIToolbar = {
         let view = UIToolbar()
         view.sizeToFit()
         
@@ -24,7 +24,7 @@ final class ValueUpdateKeyTableViewCell: UITableViewCell {
             title: "done_title".localized,
             style: .done,
             target: self,
-            action: #selector(doneButtonTap(_:))
+            action: #selector(self.doneButtonTap(_:))
         )
         
         view.items = [spacer, doneButton]


### PR DESCRIPTION
# 📌 Reference
> Add any references to help understand this pull request.


# 🔥 Cause
> If there is a reason, write why the code changes was occurred.

In keyboard accessory view's instantiate block, `UIBarButtonItem` set selector `doneButtonTap(_:)`.

But this phrase call with view's init. When it call `self` not ready.

So it doesn't set selector right.

# 📄 Changes
> Write what is changed.
> You can write more detail informations using MD syntax.

Set keyboard accessory view to `lazy var` to refer right `self`.

# 🚧 Testing
> Write how to test and results of changes using screenshots, gifs, any others.
